### PR TITLE
Upgrade vls to 0.5.5

### DIFF
--- a/Vue.novaextension/npm-shrinkwrap.json
+++ b/Vue.novaextension/npm-shrinkwrap.json
@@ -49,9 +49,9 @@
             "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA=="
         },
         "@eslint/eslintrc": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-            "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+            "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -125,9 +125,9 @@
             }
         },
         "@prettier/plugin-pug": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-1.10.0.tgz",
-            "integrity": "sha512-kxPqSSNyRLayA8Kspscam/MWIdE8cDuxA6i1FKM+EBlHIn5/jtYJB3H0WMzlZhejKv7lXOICx23d4Ak8dCurhg==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-1.10.1.tgz",
+            "integrity": "sha512-HyX0FN8pGdumKS1eiVJ8jbYh8bx2DdbvBOpuKf4+SNP1Z8OFDZorl/q4ShH7oCqMAnFj2kFCpZkuIOkD6gZv7Q==",
             "requires": {
                 "pug-lexer": "^5.0.0"
             }
@@ -327,9 +327,9 @@
             "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
         },
         "@types/node": {
-            "version": "14.14.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
-            "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg=="
+            "version": "14.14.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+            "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
         },
         "@types/normalize-package-data": {
             "version": "2.4.0",
@@ -865,9 +865,9 @@
             }
         },
         "ccount": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
-            "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+            "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
         },
         "chalk": {
             "version": "2.4.2",
@@ -1649,12 +1649,12 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
-            "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
+            "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@eslint/eslintrc": "^0.1.3",
+                "@eslint/eslintrc": "^0.2.1",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -2120,9 +2120,9 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
         "fastq": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-            "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+            "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
             "requires": {
                 "reusify": "^1.0.4"
             }
@@ -2224,9 +2224,9 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.0.tgz",
+            "integrity": "sha512-pKnaUh2TNvk+/egJdBw1h46LwyLx8BzEq+MGCf/RMCVfEHHsGOCWG00dqk91kUPPArIIwMBg9T/virxwzP03cA==",
             "optional": true
         },
         "function-bind": {
@@ -2460,9 +2460,9 @@
             "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
         },
         "hast-util-parse-selector": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
-            "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+            "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
         },
         "hast-util-to-string": {
             "version": "1.0.4",
@@ -2508,9 +2508,9 @@
             "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
         },
         "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+            "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -4468,9 +4468,9 @@
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
         },
         "run-parallel": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+            "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
         },
         "rxjs": {
             "version": "6.6.3",
@@ -4507,12 +4507,12 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sass-formatter": {
-            "version": "0.4.15",
-            "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.4.15.tgz",
-            "integrity": "sha512-EpjwQsya8DmefZawi1sNoCjKw6IGE4z18h9lKd0QPgoGGkis8nqK+mfCMS4B8OaEa0To//71yQyGV1OW1/t60g==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.5.1.tgz",
+            "integrity": "sha512-hRIyMsN9eKQCx+tQec78EtbRs+Be7vamEh+B+JCdIyIc4t2Ku84FIZHC+qjeu+Q5LDtXcHoMxS61AijNA+SZvA==",
             "requires": {
                 "@sorg/log": "^2.0.1",
-                "suf-regex": "^0.0.23",
+                "suf-regex": "^0.0.25",
                 "tslib": "^1.10.0"
             }
         },
@@ -5183,9 +5183,9 @@
             }
         },
         "suf-regex": {
-            "version": "0.0.23",
-            "resolved": "https://registry.npmjs.org/suf-regex/-/suf-regex-0.0.23.tgz",
-            "integrity": "sha512-Rupps+hO04fiskhx5YwBaiB8Bbwsy8fsqDfT8FED6DWkumWClb3em+yukbNgmAvUIbLAm7ibJoN+2Pl4golkQw==",
+            "version": "0.0.25",
+            "resolved": "https://registry.npmjs.org/suf-regex/-/suf-regex-0.0.25.tgz",
+            "integrity": "sha512-0hd6oSzoeqwFgFLtXRoA6lMndzTpgPZCSU+/sCoin0HyKnqni/GX/BkUe9Qgs4uRIV1pxsZzE2pEIbaiFX61AQ==",
             "requires": {
                 "del-cli": "^3.0.0"
             }
@@ -5333,9 +5333,9 @@
             "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
         },
         "trim-trailing-lines": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-            "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
+            "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ=="
         },
         "trough": {
             "version": "1.0.5",
@@ -5404,9 +5404,9 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-            "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+            "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ=="
         },
         "unherit": {
             "version": "1.1.3",
@@ -5734,9 +5734,9 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "v8-compile-cache": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -5840,17 +5840,17 @@
             "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA=="
         },
         "vls": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/vls/-/vls-0.5.4.tgz",
-            "integrity": "sha512-BAdsW9uYaMIEQcAK3cZsuoA+jMapOxc3RFNqiZtRDunbkv+sWrCs4xrydiPIiLHY7Pi8I/yNqBPlR/8LDlFmhA==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/vls/-/vls-0.5.5.tgz",
+            "integrity": "sha512-DDfnr83S2jAXWA0TLOy3t2g+wgTzo+hUNz8aYcF4WQrCTlNVyDsZ3wtcCa5koZVYWbfDitfBAlbqkqIpjeaDng==",
             "requires": {
-                "@prettier/plugin-pug": "^1.6.1",
+                "@prettier/plugin-pug": "^1.10.0",
                 "@starptech/prettyhtml": "^0.10.0",
                 "bootstrap-vue-helper-json": "^1.1.1",
                 "core-js": "^3.6.5",
                 "element-helper-json": "^2.0.6",
-                "eslint": "^7.9.0",
-                "eslint-plugin-vue": "^7.0.0-beta.3",
+                "eslint": "^7.11.0",
+                "eslint-plugin-vue": "^7.1.0",
                 "gridsome-helper-json": "^1.0.3",
                 "js-beautify": "^1.13.0",
                 "lodash": "^4.17.20",
@@ -5861,29 +5861,29 @@
                 "prettier-tslint": "^0.4.2",
                 "read-pkg-up": "^7.0.1",
                 "resolve": "^1.17.0",
-                "sass-formatter": "^0.4.15",
+                "sass-formatter": "^0.5.1",
                 "stylus": "^0.54.8",
                 "stylus-supremacy": "^2.14.5",
-                "typescript": "^4.0.2",
-                "vscode-css-languageservice": "4.3.3",
-                "vscode-emmet-helper": "^2.0.0",
+                "typescript": "^4.0.3",
+                "vscode-css-languageservice": "4.3.5",
+                "vscode-emmet-helper": "^2.0.8",
                 "vscode-languageserver": "7.0.0-next.7",
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "3.16.0-next.3",
                 "vscode-uri": "^2.1.2",
                 "vscode-web-custom-data": "^0.3.1",
-                "vue-eslint-parser": "^7.1.0",
+                "vue-eslint-parser": "^7.1.1",
                 "vue-onsenui-helper-json": "^1.0.2"
             }
         },
         "vscode-css-languageservice": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.3.tgz",
-            "integrity": "sha512-b2b+0oHvPmBHygDtOXX3xBvpQCa6eIQSvXnGDNSDmIC1894ZTJ2yX10vjplOO/PvV7mwhyvGPwHyY4X2HGxtKw==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.3.5.tgz",
+            "integrity": "sha512-g9Pjxt9T32jhY0nTOo7WRFm0As27IfdaAxcFa8c7Rml1ZqBn3XXbkExjzxY7sBWYm7I1Tp4dK6UHXHoUQHGwig==",
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
                 "vscode-languageserver-types": "3.16.0-next.2",
-                "vscode-nls": "^4.1.2",
+                "vscode-nls": "^5.0.0",
                 "vscode-uri": "^2.1.2"
             },
             "dependencies": {
@@ -5895,9 +5895,9 @@
             }
         },
         "vscode-emmet-helper": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.1.1.tgz",
-            "integrity": "sha512-598eqXynvHDBdjgZqjTTg3XNb0SIvlVIc22/DwqxKjTKJLqe4LDCWi0H1yYBvU0Eb1FAJSh/l04InFxuI/mDVg==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-2.0.8.tgz",
+            "integrity": "sha512-Wyf+b5pua+13eZSHCpmob1x915x/od4z6lIia9T2N4v7+CUYNxDisBu3/ShIM3qg3YiYvTCOm+Yx/CLd2khcVw==",
             "requires": {
                 "emmet": "^2.1.5",
                 "jsonc-parser": "^2.3.0",
@@ -5946,9 +5946,9 @@
             "integrity": "sha512-s/z5ZqSe7VpoXJ6JQcvwRiPPA3nG0nAcJ/HH03zoU6QaFfnkcgPK+HshC3WKPPnC2G08xA0iRB6h7kmyBB5Adg=="
         },
         "vscode-nls": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-            "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+            "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
         },
         "vscode-uri": {
             "version": "2.1.2",

--- a/Vue.novaextension/package.json
+++ b/Vue.novaextension/package.json
@@ -2,6 +2,6 @@
     "name": "Vue.novaextension",
     "version": "1.0.0",
     "dependencies": {
-        "vls": "^0.5.4"
+        "vls": "^0.5.5"
     }
 }

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -67,7 +67,8 @@ class VueLanguageServer {
                         },
                         completion: {
                             autoImport: true
-                        }
+                        },
+                        useWorkspaceDependencies: true
                     }
                 }
             }

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -64,6 +64,9 @@ class VueLanguageServer {
                         },
                         experimental: {
                             templateInterpolationService: true
+                        },
+                        completion: {
+                            autoImport: true
                         }
                     }
                 }

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -56,6 +56,15 @@ class VueLanguageServer {
         var clientOptions = {
             // The set of document syntaxes for which the server is valid
             syntaxes: ['vue'],
+            initializationOptions: {
+                config: {
+                    vetur: {
+                        format: {
+                            enable: false
+                        }
+                    }
+                }
+            }
         }
         var client = new LanguageClient(
             'tommasonegri.vue',

--- a/src/Scripts/main.js
+++ b/src/Scripts/main.js
@@ -61,6 +61,9 @@ class VueLanguageServer {
                     vetur: {
                         format: {
                             enable: false
+                        },
+                        experimental: {
+                            templateInterpolationService: true
                         }
                     }
                 }


### PR DESCRIPTION
1. close format feature for crash
> Nova LSP don't support format feature.
> It will crash when Vetur register format with send `DocumentFormattingRequest`.
> Should Nova client be ignored if it is not supported?
2. open templateInterpolationService support, you can try it. https://github.com/tommasongr/nova-vue/issues/3#issuecomment-718641886
3. open autoImport in typescript completion
4. use workspace dependencies
5. You can try these features and decide whether to open or not.

I study the LSP support in Nova editor.
The `didChangeConfiguration` support is a problem.
In VSCode, It will send full config to VLS and trigger in startup.
In Nova, It only send changed config key and value to VLS.
If you have any way of communicating with nova offical, you can talk them out.

PS. I can't find `get all configs` API, so I cant use it to send in VLS init.